### PR TITLE
Fix reading large terminfo entries

### DIFF
--- a/dec.go
+++ b/dec.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	// maxFileLength is the max file length.
-	maxFileLength = 4096
+	maxFileLength = 32768
 	// magic is the file magic for terminfo files.
 	magic = 0o432
 	// magicExtended is the file magic for terminfo files with the extended


### PR DESCRIPTION
In recent ncurses patchlevels several popular terminfo entries like xterm and xterm-256color have exceeded the size of 4096 bytes, causing this implementation of infocmp to fail. Note that ncurses 6.1 has increased the maximum entry size to 32768.

See also https://bugs.debian.org/1143527.